### PR TITLE
Use plyr's rbind.fill to prevent errors with documents with differing schema

### DIFF
--- a/R/selectDocuments.R
+++ b/R/selectDocuments.R
@@ -111,7 +111,7 @@ selectDocuments <-
               if (is.null(totalDocuments)) {
                 totalDocuments <- intermediateResult
               } else {
-                totalDocuments <- rbind(totalDocuments, intermediateResult)
+                totalDocuments <- plyr::rbind.fill(totalDocuments, intermediateResult)
             }
             requestCharge <- requestCharge + as.numeric(response$headers$`x-ms-request-charge`)
             sessionToken <- response$headers$`x-ms-session-token`


### PR DESCRIPTION
I am using your package to query a collection with differing schema between documents. I was able to use the plyr function rbind.fill to return a dataframe with NAs for missing columns. Would like to hear your thoughts on this. Thanks for the great package